### PR TITLE
Make python script more easily executable on UNIX systems

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,3 +1,4 @@
+#!/bin/python3
 """EU5 Patcher - Enable Achievements Unconditionally"""
 
 import re


### PR DESCRIPTION
To avoid having to `python3 patch.py` the script everytime instead of the simpler (and IMO more fluent) `./patch.py`, add the single line to tell any POSIX shell which program to redirect to.