### PR TITLE
Add Linux support, fixed bugs, confirmed working on 1.2 - Windows testing needed

### DIFF
--- a/patch.cpp
+++ b/patch.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -165,8 +166,7 @@ struct PatternByte
 
 struct PatternSearchResult
 {
-    std::optional<size_t> offset;
-    size_t match_count{0};
+    std::vector<size_t> offsets;
 };
 
 /**
@@ -201,18 +201,7 @@ struct PatternSearchResult
 
         if (match)
         {
-            if (result.match_count == 0)
-            {
-                result.offset = i;
-            }
-
-            ++result.match_count;
-
-            if (result.match_count > 1)
-            {
-                // No need to keep scanning; we only care that it is ambiguous.
-                break;
-            }
+            result.offsets.push_back(i);
         }
     }
 
@@ -367,6 +356,23 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
     {
         return fs::path(*fallback);
     }
+#else
+    const char *home = std::getenv("HOME");
+    if (home)
+    {
+        const std::vector<fs::path> candidates = {
+            fs::path(home) / ".local/share/Steam",
+            fs::path(home) / ".steam/steam",
+            fs::path(home) / ".var/app/com.valvesoftware.Steam/.steam/steam",
+        };
+        for (const auto &p : candidates)
+        {
+            if (fs::is_directory(p))
+            {
+                return p;
+            }
+        }
+    }
 #endif
     return std::nullopt;
 }
@@ -407,13 +413,15 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
     return tokens;
 }
 
-[[nodiscard]] std::optional<fs::path> find_steam_library_path(const fs::path &vdf_path,
-                                                              std::string_view target_appid)
+[[nodiscard]] std::vector<fs::path> find_all_steam_libraries_with_app(
+    const fs::path &vdf_path,
+    std::string_view target_appid)
 {
+    std::vector<fs::path> results;
     std::ifstream file(vdf_path);
     if (!file)
     {
-        return std::nullopt;
+        return results;
     }
 
     std::string current_path;
@@ -442,6 +450,7 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
                 continue;
             }
 
+            // 进入 apps 块
             if (tokens[0] == "apps")
             {
                 in_apps_block = true;
@@ -450,13 +459,14 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
         }
 
         // Within "apps" block
+        // 检查 AppID
         if (tokens[0] == target_appid)
         {
-            return fs::path(current_path);
+            results.push_back(fs::path(current_path));
         }
     }
 
-    return std::nullopt;
+    return results;
 }
 
 [[nodiscard]] std::optional<fs::path> get_game_folder(std::string_view name)
@@ -468,19 +478,18 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
     }
 
     const auto library_db = *steam_path_opt / "steamapps" / "libraryfolders.vdf";
-    const auto library_path = find_steam_library_path(library_db, APP_ID);
-    if (!library_path || !fs::is_directory(*library_path))
+    const auto library_paths = find_all_steam_libraries_with_app(library_db, APP_ID);
+    for (const auto &library_path : library_paths)
     {
-        return std::nullopt;
+        const auto game_folder = library_path / "steamapps" / "common" / std::string(name);
+        const auto binaries_path = game_folder / "binaries" / EU5_PATH;
+        if (fs::is_regular_file(binaries_path))
+        {
+            return game_folder;
+        }
     }
 
-    const auto game_folder = *library_path / "steamapps" / "common" / std::string(name);
-    if (!fs::is_directory(game_folder))
-    {
-        return std::nullopt;
-    }
-
-    return game_folder;
+    return std::nullopt;
 }
 
 [[nodiscard]] std::optional<fs::path> locate_eu5()
@@ -520,9 +529,8 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
     auto &data = *data_opt;
 
     std::vector<size_t> offsets;
-    offsets.reserve(PATCH_DEFINITIONS.size());
     std::vector<std::vector<PatternByte>> replacements;
-    replacements.reserve(PATCH_DEFINITIONS.size());
+    std::vector<std::string_view> labels;
 
     // Parse patterns and determine offsets
     for (const auto &patch_def : PATCH_DEFINITIONS)
@@ -530,7 +538,7 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
         const auto pattern = parse_pattern(patch_def.pattern);
         const auto search_result = find_pattern(data, pattern);
 
-        if (search_result.match_count == 0)
+        if (search_result.offsets.empty())
         {
             std::cerr << "Error: " << patch_def.label
                       << " not found. Have you patched it before?\n"
@@ -538,19 +546,16 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
             return 1;
         }
 
-        if (search_result.match_count > 1)
+        const auto replacement = parse_pattern(patch_def.replacement);
+        for (size_t offset : search_result.offsets)
         {
-            std::cerr << "Error: " << patch_def.label
-                      << " pattern is ambiguous. The pattern is ambiguous.\n";
-            return 1;
+            offsets.push_back(offset);
+            replacements.push_back(replacement);
+            labels.push_back(patch_def.label);
         }
-
-        offsets.push_back(*search_result.offset);
-        auto replacement = parse_pattern(patch_def.replacement);
-        replacements.push_back(std::move(replacement));
     }
 
-    // Create backup only after confirming both patterns exist
+    // Create backup only after confirming all patterns exist
     auto backup_path = filepath;
     backup_path += EU5_BACKUP_SUFFIX;
 
@@ -561,9 +566,9 @@ void apply_patch_bytes(std::vector<uint8_t> &data,
     }
     std::cout << "Backup created: " << backup_path << '\n';
 
-    for (size_t i = 0; i < PATCH_DEFINITIONS.size(); ++i)
+    for (size_t i = 0; i < offsets.size(); ++i)
     {
-        apply_patch_bytes(data, offsets[i], replacements[i], PATCH_DEFINITIONS[i].label);
+        apply_patch_bytes(data, offsets[i], replacements[i], labels[i]);
     }
 
     // Write back

--- a/patch.py
+++ b/patch.py
@@ -13,35 +13,52 @@ from typing import Final, Optional
 
 def get_steam_install_path() -> Optional[str]:
     """
-    Get the Steam installation path on Windows by querying the registry.
-    Returns None if Steam is not installed or if not on Windows.
+    Get the Steam installation path.
+    On Windows queries the registry. On Linux checks standard paths.
+    Returns None if Steam is not found.
     """
-    if platform.system() != "Windows":
-        return None
+    system = platform.system()
 
-    try:
-        import winreg
-    except:
-        return None
-
-    try:
-        key = winreg.OpenKey(
-            winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\\WOW6432Node\\Valve\\Steam"
-        )
-        path, _ = winreg.QueryValueEx(key, "InstallPath")
-        winreg.CloseKey(key)
-        return path
-    except FileNotFoundError:
+    if system == "Windows":
         try:
-            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\\Valve\\Steam")
-            path, _ = winreg.QueryValueEx(key, "SteamPath")
+            import winreg
+        except ImportError:
+            return None
+        try:
+            key = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\\WOW6432Node\\Valve\\Steam"
+            )
+            path, _ = winreg.QueryValueEx(key, "InstallPath")
             winreg.CloseKey(key)
             return path
-        except:
-            return None
+        except FileNotFoundError:
+            try:
+                key = winreg.OpenKey(
+                    winreg.HKEY_CURRENT_USER, r"Software\\Valve\\Steam"
+                )
+                path, _ = winreg.QueryValueEx(key, "SteamPath")
+                winreg.CloseKey(key)
+                return path
+            except Exception:
+                return None
+
+    if system == "Linux":
+        candidates = [
+            os.path.expanduser("~/.local/share/Steam"),
+            os.path.expanduser("~/.steam/steam"),
+            os.path.expanduser("~/.var/app/com.valvesoftware.Steam/.steam/steam"),
+        ]
+        for candidate in candidates:
+            if os.path.isdir(candidate):
+                return candidate
+        return None
+
+    return None
 
 
-def find_steam_library_path(vdf_path, target_appid: str):
+def find_all_steam_libraries_with_app(vdf_path: str, target_appid: str) -> list[str]:
+    """Return all Steam library paths that contain the given AppID."""
+    results: list[str] = []
     current_path = None
     in_apps_block = False
 
@@ -49,7 +66,6 @@ def find_steam_library_path(vdf_path, target_appid: str):
         for line in f:
             line = line.strip()
 
-            # 解析 path
             if line.startswith('"path"'):
                 # "path"    "E:\SteamLibrary"
                 current_path = line.split('"')[3]
@@ -66,30 +82,34 @@ def find_steam_library_path(vdf_path, target_appid: str):
 
                 # 检查 AppID
                 if line.startswith(f'"{target_appid}"'):
-                    return current_path
+                    if current_path:
+                        results.append(current_path)
 
-    return None
+    return results
 
 
-def get_game_folder(name: str) -> str:
-    """
+def get_game_folder(name: str) -> Optional[str]:
+    """2
     Get the installation folder of a Steam game by its name.
-    Returns empty string if the game is not found.
+    Checks all Steam libraries and returns the first path where the game exists.
+    Returns None if the game is not found.
     """
     steam_path = get_steam_install_path()
     if not steam_path:
         return None
 
     library_db = os.path.join(steam_path, "steamapps", "libraryfolders.vdf")
-    library_path = find_steam_library_path(library_db, "3450310")  # EU5
-    if not os.path.isdir(library_path):
+    if not os.path.isfile(library_db):
         return None
 
-    game_folders_path = os.path.join(library_path, "steamapps", "common", name)
-    if not os.path.isdir(game_folders_path):
-        return None
+    library_paths = find_all_steam_libraries_with_app(library_db, "3450310")  # EU5
+    for library_path in library_paths:
+        game_folder = os.path.join(library_path, "steamapps", "common", name)
+        binaries_path = os.path.join(game_folder, "binaries", "eu5.exe")
+        if os.path.isfile(binaries_path):
+            return game_folder
 
-    return game_folders_path
+    return None
 
 
 # Constants
@@ -176,11 +196,15 @@ PATTERN5: Final[str] = (
 PATTERN_REPLACE5: Final[str] = "e8 ?? ?? ?? ?? 80 ?? ?? ?? ?? ?? 09"
 
 
-EU5_PATH: Final[Path] = Path("eu5.exe")
-STEAM_EU5_PATH: Final[Path] = (
-    Path(get_game_folder("Europa Universalis V")) / "binaries" / "eu5.exe"
+SCRIPT_DIR: Final[Path] = Path(__file__).resolve().parent
+
+EU5_PATH: Final[Path] = SCRIPT_DIR / "eu5.exe"
+_game_folder = get_game_folder("Europa Universalis V")
+STEAM_EU5_PATH: Final[Optional[Path]] = (
+    Path(_game_folder) / "binaries" / "eu5.exe" if _game_folder else None
 )
 EU5_BACKUP_SUFFIX: Final[str] = ".backup"
+EU5_BACKUP_PATH: Final[Path] = SCRIPT_DIR / "eu5.exe.backup"
 
 debug_info = False
 
@@ -241,8 +265,8 @@ def create_backup(source: Path, dest: Path) -> None:
         raise PatchError(f"Failed to create backup: {e}") from e
 
 
-def find_pattern(data: bytes, pattern: re.Pattern[bytes]) -> int:
-    """Find the pattern in data and return its offset."""
+def find_pattern(data: bytes, pattern: re.Pattern[bytes]) -> list[int]:
+    """Find the pattern in data and return its offsets."""
     matches = list(pattern.finditer(data))
 
     if len(matches) == 0:
@@ -250,12 +274,8 @@ def find_pattern(data: bytes, pattern: re.Pattern[bytes]) -> int:
             "Pattern not found. Have you patched it before? "
             "If not, the pattern may need to be updated."
         )
-    if len(matches) > 1:
-        raise PatchError(
-            f"Multiple matches found ({len(matches)}). " f"The pattern is ambiguous."
-        )
 
-    return matches[0].start()
+    return [m.start() for m in matches]
 
 
 def apply_patch(data: bytearray, offset: int, replacement: list[int | None]) -> None:
@@ -284,11 +304,11 @@ def make_patch(filepath: Path) -> None:
     # Find every pattern and prepare replacements before touching disk
     patch_jobs: list[tuple[PatchDefinition, int, list[int | None]]] = []
     for patch_def in PATCHES:
-        # print(patch_def.pattern, "\n")
         regex = pattern_to_regex(patch_def.pattern)
-        offset = find_pattern(data, regex)
+        offsets = find_pattern(data, regex)
         replacement = pattern_to_list(patch_def.replacement)
-        patch_jobs.append((patch_def, offset, replacement))
+        for offset in offsets:
+            patch_jobs.append((patch_def, offset, replacement))
 
     # Create backup only after both patterns are confirmed
     create_backup(filepath, filepath.with_name(filepath.name + EU5_BACKUP_SUFFIX))
@@ -311,8 +331,8 @@ def main() -> int:
     """Main entry point."""
     if EU5_PATH.exists():
         path = EU5_PATH
-        print(f"Path: ./{EU5_PATH}")
-    elif STEAM_EU5_PATH.exists():
+        print(f"Path: {EU5_PATH}")
+    elif STEAM_EU5_PATH and STEAM_EU5_PATH.exists():
         path = STEAM_EU5_PATH
         print(f"Path: {STEAM_EU5_PATH}")
     else:


### PR DESCRIPTION
…EU5 1.2

- On Linux, the script now knows where to look for Steam. Previously, it only worked for Windows. This check is done automatically with "platform.system()"
- When Steam is found, the script now checks every hard drive where Steam stores games, not just the first one. It looks up for the eu5.exe file to make sure it's really there, instead of trusting an old install record that might be wrong.
- Fixed a bug where the script would crash if it found the same code pattern more than once in the game file. Now it patches all copies instead of giving up.
- The script now always looks for eu5.exe in it's own folder, no matter where you run it from.

Confirmed working on EU5 1.2. Existing patch patterns from 1.0 and 1.1 still match, no changes were needed.

Note1: tested on Linux only. Needs a Windows test.
Note2: the .cpp changes were made with AI assistance (I don't have much experience with C++), it needs review before compiling the next patch.exe.